### PR TITLE
Optimize Render Callback method of Site Count block

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -132,7 +132,7 @@ class Block {
 	 * @return string HTML markup
 	 */
 	public function render_posts_with_tag_cat() {
-		$cached = wp_cache_get( 'site_counts_block_render_posts_with_tag_cat', 'site-counts' );
+		$cached = wp_cache_get( 'site_counts_block_render_posts_with_tag_cat_' . get_the_ID(), 'site-counts' );
 
 		if ( false !== $cached ) {
 			return $cached;
@@ -181,7 +181,7 @@ class Block {
 		endif;
 
 		$html_content = ob_get_clean();
-		wp_cache_set( 'site_counts_block_render_posts_with_tag_cat', $html_content, 'site-counts', DAY_IN_SECONDS );
+		wp_cache_set( 'site_counts_block_render_posts_with_tag_cat_' . get_the_ID(), $html_content, 'site-counts', DAY_IN_SECONDS );
 
 		return $html_content;
 	}

--- a/php/Block.php
+++ b/php/Block.php
@@ -42,9 +42,9 @@ class Block {
 		add_action( 'init', [ $this, 'register_block' ] );
 
 		// Clear cache when a post is updated, post status changes, category or tag updated.
-		add_action( 'edit_term', array( $this, 'flush_caches' ), 10, 3 );
-		add_action( 'edit_category', array( $this, 'flush_caches' ), 10, 1 );
-		add_action( 'edit_post', array( $this, 'flush_caches' ), 10, 1 );
+		add_action( 'edit_term', [ $this, 'flush_caches' ], 10, 3 );
+		add_action( 'edit_category', [ $this, 'flush_caches' ], 10, 1 );
+		add_action( 'edit_post', [ $this, 'flush_caches' ], 10, 1 );
 	}
 
 	/**
@@ -87,24 +87,25 @@ class Block {
 			<h2><?php esc_html_e( 'Post Counts', 'site-counts' ); ?></h2>
 			<ul>
 				<?php 
-					foreach ( $post_types as $post_type_slug ) :
-						$post_type_object = get_post_type_object( $post_type_slug  );
-						$post_count = wp_count_posts( $post_type_slug ); 
-						?>
+				foreach ( $post_types as $post_type_slug ) :
+					$post_type_object = get_post_type_object( $post_type_slug );
+					$post_count       = wp_count_posts( $post_type_slug ); 
+					?>
 						<li>
-							<?php /* translators: 1: post count, 2: post type singular name, 3: Post type plural name */
-								echo sprintf( 
-									_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ),
-									number_format_i18n( $post_count->publish ),
-									$post_type_object->labels->singular_name,
-									$post_type_object->labels->name
-								);
+						<?php 
+							echo sprintf( 
+								/* translators: 1: post count, 2: post type singular name, 3: Post type plural name */
+								_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ),
+								number_format_i18n( $post_count->publish ),
+								$post_type_object->labels->singular_name,
+								$post_type_object->labels->name
+							);
 
-							?>
+						?>
 						</li>
 				<?php endforeach; ?>
 			</ul>
-			
+
 			<p>
 				<?php
 					echo sprintf(
@@ -135,43 +136,47 @@ class Block {
 			return $cached;
 		}
 
-		$query = new WP_Query( [
-			'no_found_rows' => true,
-			'fields' => 'ids',
-			'post_type' => [ 'post', 'page' ],
-			'post_status' => 'any',
-			'date_query' => [
-				[
-					'hour'      => 9,
-					'compare'   => '>=',
+		$query = new WP_Query(
+			[
+				'no_found_rows'  => true,
+				'fields'         => 'ids',
+				'post_type'      => [ 'post', 'page' ],
+				'post_status'    => 'any',
+				'date_query'     => [
+					[
+						'hour'    => 9,
+						'compare' => '>=',
+					],
+					[
+						'hour'    => 17,
+						'compare' => '<=',
+					],
 				],
-				[
-					'hour' => 17,
-					'compare'=> '<=',
-				],
-			],
-			'tag'  => 'foo',
-			'category_name'  => 'baz',
-			'posts_per_page' => 6,
-		] );
+				'tag'            => 'foo',
+				'category_name'  => 'baz',
+				'posts_per_page' => 6,
+			] 
+		);
 
 		ob_start();
 
 		if ( $query->have_posts() ) : 
-			$posts = $query->posts;
+			$posts      = $query->posts;
 			$skip_index = array_search( get_the_ID(), $posts );
 
 			if ( $skip_index !== false ) :
 				unset( $posts[ $skip_index ] );
-			endif; ?>
+			endif; 
+			?>
 
 			<h2><?php _e( '5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
 			<ul>
 				<?php foreach ( array_slice( $posts, 0, 5 ) as $post ) : ?>
-					<li><?php echo get_the_title( $post ) ?></li>
+					<li><?php echo get_the_title( $post ); ?></li>
 				<?php endforeach; ?>
 			</ul>
-		<?php endif;
+			<?php 
+		endif;
 
 		$html_content = ob_get_clean();
 		wp_cache_set( 'render_posts_with_tag_cat', $html_content, 'site-counts', DAY_IN_SECONDS );

--- a/php/Block.php
+++ b/php/Block.php
@@ -171,7 +171,7 @@ class Block {
 			endif; 
 			?>
 
-			<h2><?php _e( '5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
+			<h2><?php esc_html_e( '5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
 			<ul>
 				<?php foreach ( array_slice( $posts, 0, 5 ) as $post ) : ?>
 					<li><?php echo esc_html( get_the_title( $post ) ); ?></li>

--- a/php/Block.php
+++ b/php/Block.php
@@ -157,9 +157,9 @@ class Block {
 						'compare' => '<=',
 					],
 				],
-				'tag'                   => 'foo',
-				'category_name'         => 'baz',
-				'posts_per_page'        => 6,
+				'tag'                    => 'foo',
+				'category_name'          => 'baz',
+				'posts_per_page'         => 6,
 			] 
 		);
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -54,7 +54,7 @@ class Block {
 	 * @return void
 	 */
 	public function flush_caches() {
-		wp_cache_delete( 'render_posts_with_tag_cat', 'site-counts' );
+		wp_cache_delete( 'site_counts_block_render_posts_with_tag_cat', 'site-counts' );
 	}
 
 	/**
@@ -132,7 +132,7 @@ class Block {
 	 * @return string HTML markup
 	 */
 	public function render_posts_with_tag_cat() {
-		$cached = wp_cache_get( 'render_posts_with_tag_cat', 'site-counts' );
+		$cached = wp_cache_get( 'site_counts_block_render_posts_with_tag_cat', 'site-counts' );
 
 		if ( false !== $cached ) {
 			return $cached;
@@ -181,7 +181,7 @@ class Block {
 		endif;
 
 		$html_content = ob_get_clean();
-		wp_cache_set( 'render_posts_with_tag_cat', $html_content, 'site-counts', DAY_IN_SECONDS );
+		wp_cache_set( 'site_counts_block_render_posts_with_tag_cat', $html_content, 'site-counts', DAY_IN_SECONDS );
 
 		return $html_content;
 	}

--- a/php/Block.php
+++ b/php/Block.php
@@ -49,6 +49,7 @@ class Block {
 	 * Flush cached HTML markup.
 	 * HTML markup cached in render_posts_with_tag_cat() method.
 	 *
+	 * @param int $post_id Post id which is being edited.
 	 * @return void
 	 */
 	public function flush_caches( $post_id ) {
@@ -91,14 +92,14 @@ class Block {
 					?>
 						<li>
 						<?php 
-							echo sprintf( 
-								esc_html(
+							echo esc_html(
+								sprintf( 
 									/* translators: %1$s: post count. %2$s: post type singular name. %3$s: Post type plural name. */
-									_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ) 
-								),
-								esc_html( number_format_i18n( $post_count->publish ) ),
-								esc_html( $post_type_object->labels->singular_name ),
-								esc_html( $post_type_object->labels->name )
+									_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ), // phpcs:ignore WordPress.WP.I18n.MismatchedPlaceholders -- Singular and plural placeholders are intentionally different.
+									number_format_i18n( $post_count->publish ),
+									$post_type_object->labels->singular_name,
+									$post_type_object->labels->name
+								)
 							);
 
 						?>

--- a/php/Block.php
+++ b/php/Block.php
@@ -64,11 +64,11 @@ class Block {
 	 */
 	public function render_callback( $attributes, $content, $block ) {
 		$post_types = get_post_types( [ 'public' => true ] );
-		$class_name = $attributes['className'];
+		$class_name = $attributes['className'] ?? false;
 		ob_start();
 
 		?>
-		<div class="<?php echo $class_name; ?>">
+		<div class="<?php echo esc_attr( $class_name ); ?>">
 			<h2>Post Counts</h2>
 			<ul>
 			<?php
@@ -90,7 +90,7 @@ class Block {
 			<?php endforeach; ?>
 			</ul>
 			
-			<p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
+			<p><?php echo 'The current post ID is ' . get_the_ID() . '.'; ?></p>
 
 			<?php
 			$query = new WP_Query( [

--- a/php/Block.php
+++ b/php/Block.php
@@ -94,8 +94,10 @@ class Block {
 						<li>
 						<?php 
 							echo sprintf( 
-								/* translators: 1: post count, 2: post type singular name, 3: Post type plural name */
-								esc_html( _n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ) ),
+								esc_html(
+									/* translators: %1$s: post count. %2$s: post type singular name. %3$s: Post type plural name. */
+									_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ) 
+								),
 								esc_html( number_format_i18n( $post_count->publish ) ),
 								esc_html( $post_type_object->labels->singular_name ),
 								esc_html( $post_type_object->labels->name )

--- a/php/Block.php
+++ b/php/Block.php
@@ -120,8 +120,8 @@ class Block {
 	 * @return string HTML markup
 	 */
 	public function render_posts_with_tag_cat() {
-		$tag = get_term_by( 'name', 'foo', 'post_tag' );
-		$cat = get_term_by( 'name', 'baz', 'category' );
+		$tag       = get_term_by( 'name', 'foo', 'post_tag' );
+		$cat       = get_term_by( 'name', 'baz', 'category' );
 		$tag_count = 0;
 		$cat_count = 0;
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -68,20 +68,20 @@ class Block {
 		ob_start();
 
 		?>
-        <div class="<?php echo $class_name; ?>">
+		<div class="<?php echo $class_name; ?>">
 			<h2>Post Counts</h2>
 			<ul>
 			<?php
 			foreach ( $post_types as $post_type_slug ) :
-                $post_type_object = get_post_type_object( $post_type_slug  );
-                $post_count = count(
-                    get_posts(
+				$post_type_object = get_post_type_object( $post_type_slug  );
+				$post_count = count(
+					get_posts(
 						[
 							'post_type' => $post_type_slug,
 							'posts_per_page' => -1,
 						]
 					)
-                );
+				);
 
 				?>
 				<li><?php echo 'There are ' . $post_count . ' ' .
@@ -103,19 +103,19 @@ class Block {
 						'compare'=> '<=',
 					),
 				),
-                'tag'  => 'foo',
-                'category_name'  => 'baz',
-				  'post__not_in' => [ get_the_ID() ],
+				'tag'  => 'foo',
+				'category_name'  => 'baz',
+				'post__not_in' => [ get_the_ID() ],
 			));
 
 			if ( $query->have_posts() ) :
 				?>
 				 <h2>5 posts with the tag of foo and the category of baz</h2>
-                <ul>
-                <?php
+				 <ul>
+				 <?php
 
-                 foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-                    ?><li><?php echo $post->post_title ?></li><?php
+				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
+					?><li><?php echo $post->post_title ?></li><?php
 				endforeach;
 			endif;
 		 	?>

--- a/php/Block.php
+++ b/php/Block.php
@@ -9,6 +9,7 @@ namespace XWP\SiteCounts;
 
 use WP_Block;
 use WP_Query;
+use WP_Term;
 
 /**
  * The Site Counts dynamic block.
@@ -40,20 +41,6 @@ class Block {
 	 */
 	public function init() {
 		add_action( 'init', [ $this, 'register_block' ] );
-
-		// Clear cache when a post is updated, post status changes, category or tag updated.
-		add_action( 'edit_post', [ $this, 'flush_caches' ], 10, 1 );
-	}
-
-	/**
-	 * Flush cached HTML markup.
-	 * HTML markup cached in render_posts_with_tag_cat() method.
-	 *
-	 * @param int $post_id Post id which is being edited.
-	 * @return void
-	 */
-	public function flush_caches( $post_id ) {
-		wp_cache_delete( 'site_counts_block_render_posts_with_tag_cat_' . $post_id, 'site-counts' );
 	}
 
 	/**
@@ -133,7 +120,20 @@ class Block {
 	 * @return string HTML markup
 	 */
 	public function render_posts_with_tag_cat() {
-		$cached = wp_cache_get( 'site_counts_block_render_posts_with_tag_cat_' . get_the_ID(), 'site-counts' );
+		$tag = get_term_by( 'name', 'foo', 'post_tag' );
+		$cat = get_term_by( 'name', 'baz', 'category' );
+		$tag_count = 0;
+		$cat_count = 0;
+
+		if ( $tag instanceof WP_Term ) {
+			$tag_count = $tag->count;
+		}
+
+		if ( $cat instanceof WP_Term ) {
+			$cat_count = $cat->count;
+		}
+
+		$cached = wp_cache_get( 'site_counts_block_render_posts_with_tag_cat_' . $tag_count . $cat_count, 'site-counts' );
 
 		if ( false !== $cached ) {
 			return $cached;
@@ -195,7 +195,7 @@ class Block {
 		endif;
 
 		$html_content = ob_get_clean();
-		wp_cache_set( 'site_counts_block_render_posts_with_tag_cat_' . get_the_ID(), $html_content, 'site-counts', DAY_IN_SECONDS );
+		wp_cache_set( 'site_counts_block_render_posts_with_tag_cat_' . $tag_count . $cat_count, $html_content, 'site-counts', DAY_IN_SECONDS );
 
 		return $html_content;
 	}

--- a/php/Block.php
+++ b/php/Block.php
@@ -63,7 +63,7 @@ class Block {
 	 * @return string The markup of the block.
 	 */
 	public function render_callback( $attributes, $content, $block ) {
-		$post_types = get_post_types(  [ 'public' => true ] );
+		$post_types = get_post_types( [ 'public' => true ] );
 		$class_name = $attributes['className'];
 		ob_start();
 
@@ -93,33 +93,31 @@ class Block {
 			<p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
 
 			<?php
-			$query = new WP_Query(  array(
-				'post_type' => ['post', 'page'],
+			$query = new WP_Query( [
+				'post_type' => [ 'post', 'page' ],
 				'post_status' => 'any',
-				'date_query' => array(
-					array(
+				'date_query' => [
+					[
 						'hour'      => 9,
 						'compare'   => '>=',
-					),
-					array(
+					],
+					[
 						'hour' => 17,
 						'compare'=> '<=',
-					),
-				),
+					],
+				],
 				'tag'  => 'foo',
 				'category_name'  => 'baz',
 				'post__not_in' => [ get_the_ID() ],
-			));
+			] );
 
-			if ( $query->have_posts() ) :
-				?>
-				 <h2>5 posts with the tag of foo and the category of baz</h2>
-				 <ul>
-				 	<?php foreach ( array_slice( $query->posts, 0, 5 ) as $post ) : ?>
+			if ( $query->have_posts() ) : ?>
+				<h2>5 posts with the tag of foo and the category of baz</h2>
+				<ul>
+					<?php foreach ( array_slice( $query->posts, 0, 5 ) as $post ) : ?>
 						<li><?php echo $post->post_title ?></li>
 					<?php endforeach;
-			endif;
-		 	?>
+			endif; ?>
 			</ul>
 		</div>
 		<?php

--- a/php/Block.php
+++ b/php/Block.php
@@ -94,8 +94,8 @@ class Block {
 						<?php 
 							echo esc_html(
 								sprintf( 
-									/* translators: %1$s: post count. %2$s: post type singular name. %3$s: Post type plural name. */
-									_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ), // phpcs:ignore WordPress.WP.I18n.MismatchedPlaceholders -- Singular and plural placeholders are intentionally different.
+									/* translators: %1$d: post count. %2$s: post type singular name. %3$s: Post type plural name. */
+									_n( 'There is %1$d %2$s', 'There are %1$d %3$s', $post_count->publish, 'site-counts' ), // phpcs:ignore WordPress.WP.I18n.MismatchedPlaceholders -- Singular and plural placeholders are intentionally different.
 									number_format_i18n( $post_count->publish ),
 									$post_type_object->labels->singular_name,
 									$post_type_object->labels->name
@@ -111,7 +111,7 @@ class Block {
 				<?php
 					echo sprintf(
 						/* translators: 1: current post id */
-						esc_html__( 'The current post ID is %1$s.', 'site-counts' ),
+						esc_html__( 'The current post ID is %1$d.', 'site-counts' ),
 						get_the_ID()
 					); 
 				?>
@@ -167,12 +167,25 @@ class Block {
 
 			if ( false !== $skip_index ) :
 				unset( $posts[ $skip_index ] );
-			endif; 
+			endif;
+
+			$posts = array_slice( $posts, 0, 5 );
 			?>
 
-			<h2><?php esc_html_e( '5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
+
+			<h2>
+				<?php
+					echo esc_html(
+						sprintf( 
+							/* translators: %1$s: post count */
+							_n( '%1$d post with the tag of foo and the category of baz', '%1$d posts with the tag of foo and the category of baz', count( $posts ), 'site-counts' ),
+							number_format_i18n( count( $posts ) ),
+						)
+					);
+				?>
+			</h2>
 			<ul>
-				<?php foreach ( array_slice( $posts, 0, 5 ) as $post ) : ?>
+				<?php foreach ( $posts as $post ) : ?>
 					<li><?php echo esc_html( get_the_title( $post ) ); ?></li>
 				<?php endforeach; ?>
 			</ul>

--- a/php/Block.php
+++ b/php/Block.php
@@ -42,8 +42,6 @@ class Block {
 		add_action( 'init', [ $this, 'register_block' ] );
 
 		// Clear cache when a post is updated, post status changes, category or tag updated.
-		add_action( 'edit_term', [ $this, 'flush_caches' ], 10, 3 );
-		add_action( 'edit_category', [ $this, 'flush_caches' ], 10, 1 );
 		add_action( 'edit_post', [ $this, 'flush_caches' ], 10, 1 );
 	}
 
@@ -53,8 +51,8 @@ class Block {
 	 *
 	 * @return void
 	 */
-	public function flush_caches() {
-		wp_cache_delete( 'site_counts_block_render_posts_with_tag_cat', 'site-counts' );
+	public function flush_caches( $post_id ) {
+		wp_cache_delete( 'site_counts_block_render_posts_with_tag_cat_' . $post_id, 'site-counts' );
 	}
 
 	/**

--- a/php/Block.php
+++ b/php/Block.php
@@ -95,10 +95,10 @@ class Block {
 						<?php 
 							echo sprintf( 
 								/* translators: 1: post count, 2: post type singular name, 3: Post type plural name */
-								_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ),
-								number_format_i18n( $post_count->publish ),
-								$post_type_object->labels->singular_name,
-								$post_type_object->labels->name
+								esc_html( _n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ) ),
+								esc_html( number_format_i18n( $post_count->publish ) ),
+								esc_html( $post_type_object->labels->singular_name ),
+								esc_html( $post_type_object->labels->name )
 							);
 
 						?>
@@ -110,13 +110,13 @@ class Block {
 				<?php
 					echo sprintf(
 						/* translators: 1: current post id */
-						__( 'The current post ID is %1$s.', 'site-counts' ),
+						esc_html__( 'The current post ID is %1$s.', 'site-counts' ),
 						get_the_ID()
 					); 
 				?>
 			</p>
 
-			<?php echo $this->render_posts_with_tag_cat(); ?>
+			<?php echo wp_kses_post( $this->render_posts_with_tag_cat() ); ?>
 		</div>
 		<?php
 
@@ -132,7 +132,7 @@ class Block {
 	public function render_posts_with_tag_cat() {
 		$cached = wp_cache_get( 'render_posts_with_tag_cat', 'site-counts' );
 
-		if ( $cached !== false ) {
+		if ( false !== $cached ) {
 			return $cached;
 		}
 
@@ -164,7 +164,7 @@ class Block {
 			$posts      = $query->posts;
 			$skip_index = array_search( get_the_ID(), $posts );
 
-			if ( $skip_index !== false ) :
+			if ( false !== $skip_index ) :
 				unset( $posts[ $skip_index ] );
 			endif; 
 			?>
@@ -172,7 +172,7 @@ class Block {
 			<h2><?php _e( '5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
 			<ul>
 				<?php foreach ( array_slice( $posts, 0, 5 ) as $post ) : ?>
-					<li><?php echo get_the_title( $post ); ?></li>
+					<li><?php echo esc_html( get_the_title( $post ) ); ?></li>
 				<?php endforeach; ?>
 			</ul>
 			<?php 

--- a/php/Block.php
+++ b/php/Block.php
@@ -141,11 +141,13 @@ class Block {
 
 		$query = new WP_Query(
 			[
-				'no_found_rows'  => true,
-				'fields'         => 'ids',
-				'post_type'      => [ 'post', 'page' ],
-				'post_status'    => 'any',
-				'date_query'     => [
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'fields'                 => 'ids',
+				'post_type'              => [ 'post', 'page' ],
+				'post_status'            => 'any',
+				'date_query'             => [
 					[
 						'hour'    => 9,
 						'compare' => '>=',
@@ -155,9 +157,9 @@ class Block {
 						'compare' => '<=',
 					],
 				],
-				'tag'            => 'foo',
-				'category_name'  => 'baz',
-				'posts_per_page' => 6,
+				'tag'                   => 'foo',
+				'category_name'         => 'baz',
+				'posts_per_page'        => 6,
 			] 
 		);
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -86,7 +86,6 @@ class Block {
 								);
 
 							?>
-
 						</li>
 				<?php endforeach; ?>
 			</ul>

--- a/php/Block.php
+++ b/php/Block.php
@@ -109,11 +109,11 @@ class Block {
 
 			<p>
 				<?php
-					echo sprintf(
+					echo esc_html( sprintf(
 						/* translators: 1: current post id */
-						esc_html__( 'The current post ID is %1$d.', 'site-counts' ),
+						__( 'The current post ID is %1$d.', 'site-counts' ),
 						get_the_ID()
-					); 
+					) ); 
 				?>
 			</p>
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -109,11 +109,13 @@ class Block {
 
 			<p>
 				<?php
-					echo esc_html( sprintf(
+					echo esc_html(
+						sprintf(
 						/* translators: 1: current post id */
-						__( 'The current post ID is %1$d.', 'site-counts' ),
-						get_the_ID()
-					) ); 
+							__( 'The current post ID is %1$d.', 'site-counts' ),
+							get_the_ID()
+						) 
+					); 
 				?>
 			</p>
 

--- a/php/Block.php
+++ b/php/Block.php
@@ -69,25 +69,26 @@ class Block {
 
 		?>
 		<div class="<?php echo esc_attr( $class_name ); ?>">
-			<h2>Post Counts</h2>
+			<h2><?php esc_html_e( 'Post Counts', 'site-counts' ); ?></h2>
 			<ul>
-			<?php
-			foreach ( $post_types as $post_type_slug ) :
-				$post_type_object = get_post_type_object( $post_type_slug  );
-				$post_count = count(
-					get_posts(
-						[
-							'post_type' => $post_type_slug,
-							'posts_per_page' => -1,
-						]
-					)
-				);
+				<?php 
+					foreach ( $post_types as $post_type_slug ) :
+						$post_type_object = get_post_type_object( $post_type_slug  );
+						$post_count = wp_count_posts( $post_type_slug ); 
+						?>
+						<li>
+							<?php /* translators: 1: post count, 2: post type singular name, 3: Post type plural name */
+								echo sprintf( 
+									_n( 'There is %1$s %2$s', 'There are %1$s %3$s', $post_count->publish, 'site-counts' ),
+									number_format_i18n( $post_count->publish ),
+									$post_type_object->labels->singular_name,
+									$post_type_object->labels->name
+								);
 
-				?>
-				<li>
-					<?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.'; ?>
-				</li>
-			<?php endforeach; ?>
+							?>
+
+						</li>
+				<?php endforeach; ?>
 			</ul>
 			
 			<p><?php echo 'The current post ID is ' . get_the_ID() . '.'; ?></p>

--- a/php/Block.php
+++ b/php/Block.php
@@ -91,10 +91,20 @@ class Block {
 				<?php endforeach; ?>
 			</ul>
 			
-			<p><?php echo 'The current post ID is ' . get_the_ID() . '.'; ?></p>
+			<p>
+				<?php
+					echo sprintf(
+						/* translators: 1: current post id */
+						__( 'The current post ID is %1$s.', 'site-counts' ),
+						get_the_ID()
+					); 
+				?>
+			</p>
 
 			<?php
 			$query = new WP_Query( [
+				'no_found_rows' => true,
+				'fields' => 'ids',
 				'post_type' => [ 'post', 'page' ],
 				'post_status' => 'any',
 				'date_query' => [
@@ -109,14 +119,21 @@ class Block {
 				],
 				'tag'  => 'foo',
 				'category_name'  => 'baz',
-				'post__not_in' => [ get_the_ID() ],
+				'posts_per_page' => 6,
 			] );
 
-			if ( $query->have_posts() ) : ?>
-				<h2>5 posts with the tag of foo and the category of baz</h2>
+			if ( $query->have_posts() ) : 
+				$posts = $query->posts;
+				$skip_index = array_search( get_the_ID(), $posts );
+
+				if ( $skip_index !== false ) :
+					unset( $posts[ $skip_index ] );
+				endif; ?>
+
+				<h2><?php _e( '5 posts with the tag of foo and the category of baz', 'site-counts' ); ?></h2>
 				<ul>
-					<?php foreach ( array_slice( $query->posts, 0, 5 ) as $post ) : ?>
-						<li><?php echo $post->post_title ?></li>
+					<?php foreach ( array_slice( $posts, 0, 5 ) as $post ) : ?>
+						<li><?php echo get_the_title( $post ) ?></li>
 					<?php endforeach;
 			endif; ?>
 			</ul>

--- a/php/Block.php
+++ b/php/Block.php
@@ -172,16 +172,16 @@ class Block {
 			endif;
 
 			$posts = array_slice( $posts, 0, 5 );
+			$cont_posts = count( $posts );
 			?>
-
 
 			<h2>
 				<?php
 					echo esc_html(
 						sprintf( 
 							/* translators: %1$s: post count */
-							_n( '%1$d post with the tag of foo and the category of baz', '%1$d posts with the tag of foo and the category of baz', count( $posts ), 'site-counts' ),
-							number_format_i18n( count( $posts ) ),
+							_n( '%1$d post with the tag of foo and the category of baz', '%1$d posts with the tag of foo and the category of baz', $cont_posts, 'site-counts' ),
+							number_format_i18n( $cont_posts ),
 						)
 					);
 				?>

--- a/php/Block.php
+++ b/php/Block.php
@@ -84,10 +84,13 @@ class Block {
 				);
 
 				?>
-				<li><?php echo 'There are ' . $post_count . ' ' .
-					  $post_type_object->labels->name . '.'; ?></li>
-			<?php endforeach;	?>
-			</ul><p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
+				<li>
+					<?php echo 'There are ' . $post_count . ' ' . $post_type_object->labels->name . '.'; ?>
+				</li>
+			<?php endforeach; ?>
+			</ul>
+			
+			<p><?php echo 'The current post ID is ' . $_GET['post_id'] . '.'; ?></p>
 
 			<?php
 			$query = new WP_Query(  array(
@@ -112,11 +115,9 @@ class Block {
 				?>
 				 <h2>5 posts with the tag of foo and the category of baz</h2>
 				 <ul>
-				 <?php
-
-				foreach ( array_slice( $query->posts, 0, 5 ) as $post ) :
-					?><li><?php echo $post->post_title ?></li><?php
-				endforeach;
+				 	<?php foreach ( array_slice( $query->posts, 0, 5 ) as $post ) : ?>
+						<li><?php echo $post->post_title ?></li>
+					<?php endforeach;
 			endif;
 		 	?>
 			</ul>

--- a/php/Block.php
+++ b/php/Block.php
@@ -171,7 +171,7 @@ class Block {
 				unset( $posts[ $skip_index ] );
 			endif;
 
-			$posts = array_slice( $posts, 0, 5 );
+			$posts      = array_slice( $posts, 0, 5 );
 			$cont_posts = count( $posts );
 			?>
 


### PR DESCRIPTION
- Fix PHP Notices being thrown because of accessing array keys which do not exist
- Add escaping for all the HTML being returned
- Improve query to count the posts in a post type by using `wp_count_posts()` instead of performing a WP_Query. `wp_count_posts()` does a separate count mysql query and also caches the results in object cache.
- Update the WP_Query to get 5 posts for a tag and category - Remove use of `post__not_in` which makes query different different for each post ID and reduces query cache at MySQL level. Also set `no_found_rows` as we do not need count in this query and fetch only `ids` to avoid querying extra data that we do not need here. Also disable `update_post_meta_cache` and `update_post_term_cache` to avoid cache udpate queries.
- Cache the HTML output in object cache with TTL of 24 hours, If this was even complex query I would have preferred to rebuild the cache a cronjob or a separate request. Right now cache is rebuilt in the same HTTP request. But I think this is a simple enough query that can be regenerated in the same request. (Do note: With the block editor rendering the server render in the editor, this cache does get generated in the backend when you save the post)
- Correctly localize the output strings, Use plural and singular strings wherever possible to make them more accurate of the content.